### PR TITLE
Workaround for SourceGenerator build error

### DIFF
--- a/Gltf/GltfLoader/GltfLoader.csproj
+++ b/Gltf/GltfLoader/GltfLoader.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Analyzer Include="..\GltfGenerator\bin\$(Configuration)\netstandard2.0\GltfGenerator.dll" />
+    <Analyzer Include="..\GltfGenerator\bin\$(Configuration)\netstandard2.0\GltfGenerator.dll;..\GltfGenerator\bin\$(Configuration)\netstandard2.0\System.Text.Json.dll" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #8

I'm not particularly happy with this fix, and [by my reading](https://devblogs.microsoft.com/dotnet/introducing-c-source-generators/) of how SourceGenerators should be referenced, we shouldn't even need the Analyzer explicitly defined in the ItemGroup (L21-L23), we should simply include in the ProjectReference `OutputItemType="Analyzer"` however that's not working for me with VS 16.8.0 Preview 2.1.

It doesn't seem to pull in the dependencies of the source generator project and hence fails to find this dependency on `System.Text.Json` unless I explicitly include it like so - even though it itself probably contains no analysers.  I found this by inserting a `System.Diagnostics.Debugger.Launch();` into `GltfSourceGenerator.Initialize` and rebuilding, and debugging the execution of the source generator.

Hopefully when .NET 5 is released this can be tidied up, but in the meantime this ugly proposal appears to work...