### PR TITLE
Update GLTF source generator to .NET 5 final specs

### DIFF
--- a/Gltf/GltfGenerator/GltfGenerator.csproj
+++ b/Gltf/GltfGenerator/GltfGenerator.csproj
@@ -1,22 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <LangVersion>preview</LangVersion>
-    <Version>2.0.0</Version>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
+  
+  <!-- Package references needed for source generators -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
+  </ItemGroup>
+
+  <!-- External dependencies -->
+  <!-- See https://github.com/dotnet/roslyn-sdk/tree/main/samples/CSharp/SourceGenerators -->
+  <ItemGroup>
+    <PackageReference Include="System.CodeDom" Version="5.0.0" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" GeneratePathProperty="true" PrivateAssets="all" />
+  </ItemGroup>
 
   <PropertyGroup>
-    <RestoreAdditionalProjectSources>https://dotnet.myget.org/F/roslyn/api/v3/index.json ;$(RestoreAdditionalProjectSources)</RestoreAdditionalProjectSources>
+    <GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0-3.final" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="3.1.0" />
-    <PackageReference Include="System.CodeDom" Version="4.7.0" />
-    <PackageReference Include="System.Text.Json" Version="4.7.1" />
-  </ItemGroup>
+  <Target Name="GetDependencyTargetPaths">
+    <ItemGroup>
+      <TargetPathWithTargetPlatformMoniker Include="$(PKGSystem_CodeDom)\lib\netstandard2.0\System.CodeDom.dll" IncludeRuntimeDependency="false" />
+      <TargetPathWithTargetPlatformMoniker Include="$(PKGSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" IncludeRuntimeDependency="false" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/Gltf/GltfGenerator/GltfGenerator.csproj
+++ b/Gltf/GltfGenerator/GltfGenerator.csproj
@@ -10,9 +10,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
   </ItemGroup>
 
-  <!-- External dependencies -->
-  <!-- See https://github.com/dotnet/roslyn-sdk/tree/main/samples/CSharp/SourceGenerators -->
-  <ItemGroup>
+  <ItemGroup Label="External dependencies">
     <PackageReference Include="System.CodeDom" Version="5.0.0" GeneratePathProperty="true" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" GeneratePathProperty="true" PrivateAssets="all" />
   </ItemGroup>

--- a/Gltf/GltfGenerator/GltfGenerator.csproj
+++ b/Gltf/GltfGenerator/GltfGenerator.csproj
@@ -5,8 +5,7 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   
-  <!-- Package references needed for source generators -->
-  <ItemGroup>
+  <ItemGroup Label="Package references needed for source generators">
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all" />
   </ItemGroup>

--- a/Gltf/GltfGenerator/GltfGenerator.csproj
+++ b/Gltf/GltfGenerator/GltfGenerator.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   
   <ItemGroup Label="Package references needed for source generators">
@@ -11,18 +12,17 @@
   </ItemGroup>
 
   <ItemGroup Label="External dependencies">
-    <PackageReference Include="System.CodeDom" Version="5.0.0" GeneratePathProperty="true" PrivateAssets="all" />
-    <PackageReference Include="System.Text.Json" Version="5.0.2" GeneratePathProperty="true" PrivateAssets="all" />
+    <PackageReference Include="System.CodeDom" Version="5.0.0" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="5.0.1" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup>
     <GetTargetPathDependsOn>$(GetTargetPathDependsOn);GetDependencyTargetPaths</GetTargetPathDependsOn>
   </PropertyGroup>
 
-  <Target Name="GetDependencyTargetPaths">
+  <Target Name="GetDependencyTargetPaths" DependsOnTargets="ResolveReferences">
     <ItemGroup>
-      <TargetPathWithTargetPlatformMoniker Include="$(PKGSystem_CodeDom)\lib\netstandard2.0\System.CodeDom.dll" IncludeRuntimeDependency="false" />
-      <TargetPathWithTargetPlatformMoniker Include="$(PKGSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" IncludeRuntimeDependency="false" />
+      <TargetPathWithTargetPlatformMoniker Include="@(ReferenceCopyLocalPaths)" IncludeRuntimeDependency="false" />
     </ItemGroup>
   </Target>
 

--- a/Gltf/GltfGenerator/GltfGenerator.props
+++ b/Gltf/GltfGenerator/GltfGenerator.props
@@ -1,0 +1,5 @@
+﻿<Project>
+    <ItemGroup>
+        <CompilerVisibleProperty Include="GltfGenerator_GltfSchemaPath" />
+    </ItemGroup>
+</Project>

--- a/Gltf/GltfGenerator/Tasks/GltfSourceGenerator.cs
+++ b/Gltf/GltfGenerator/Tasks/GltfSourceGenerator.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
@@ -9,11 +10,12 @@ namespace GltfGenerator.Tasks
     [Generator]
     public class GltfSourceGenerator : ISourceGenerator
     {
-        public string? GltfSchema { get; set; } = @"..\Gltf\specification\2.0\schema\glTF.schema.json";
-
-        public void Execute(SourceGeneratorContext context)
+        public void Execute(GeneratorExecutionContext context)
         {
-            CodeGenerator generator = new CodeGenerator(GltfSchema);
+            if (!context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.GltfGenerator_GltfSchemaPath", out var path))
+                throw new InvalidOperationException("Missing GltfGenerator_GltfSchemaPath property in MSBuild file.");
+            
+            CodeGenerator generator = new CodeGenerator(path);
             generator.ParseSchemas();
             generator.ExpandSchemaReferences();
             generator.EvaluateInheritance();
@@ -27,7 +29,7 @@ namespace GltfGenerator.Tasks
             }
         }
 
-        public void Initialize(InitializationContext context)
+        public void Initialize(GeneratorInitializationContext context)
         {
         }
     }

--- a/Gltf/GltfLoader/GltfLoader.csproj
+++ b/Gltf/GltfLoader/GltfLoader.csproj
@@ -2,24 +2,29 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <Description>C# reference loader for GLTF 2.0</Description>
     <PackageIconUrl>https://github.com/KhronosGroup/glTF/blob/master/specification/figures/gltf.png</PackageIconUrl>
     <PackageTags>GLTF loader C#</PackageTags>
     <Version>2.0.0</Version>
-    <GltfSchema>$(MSBuildThisFileDirectory)..\Gltf\specification\2.0\schema\glTF.schema.json</GltfSchema>
   </PropertyGroup>
     
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="4.7.1" />
+    <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 
+  <!-- Reference source generator -->
+  <!-- See https://github.com/dotnet/roslyn-sdk/tree/main/samples/CSharp/SourceGenerators -->
   <ItemGroup>
-    <ProjectReference Include="..\GltfGenerator\GltfGenerator.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\GltfGenerator\GltfGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Analyzer Include="..\GltfGenerator\bin\$(Configuration)\netstandard2.0\GltfGenerator.dll" />
-  </ItemGroup>
+  <!-- Manually reference the generator props (needed because we locally reference the generator) -->
+  <Import Project="..\GltfGenerator\GltfGenerator.props" />
+
+  <!-- Pass schema path to source generator. -->
+  <PropertyGroup>
+    <GltfGenerator_GltfSchemaPath>$(MSBuildThisFileDirectory)..\Gltf\specification\2.0\schema\glTF.schema.json</GltfGenerator_GltfSchemaPath>
+  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
I get build errors when building the GltfLoader project with the final .NET 5.0 SDK installed:

```
Warning: Method 'Initialize' in type 'GltfGenerator.Tasks.GltfSourceGenerator' from assembly 'GltfGenerator, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null' does not have an implementation.
Error CS0234: The type or namespace name 'Schema' does not exist in the namespace 'GltfLoader'
   .... <lots more similar errors> ...
```

I'm not sure what is causing the source generator to fail exactly, but I saw that the final .NET 5 version of source generators made several breaking changes to the source generators spec. So I took the opportunity to update to the final version of the spec for the GltfGenerator and GltfLoader projects.

I tried updating the Shaders.Tasks project too, but it seems that local project references are problematic in a source generator, so the Tasks project would need to be combined with the Shaders project. That's quite a bit of disruption, so I'll just contribute the Gltf changes for now.